### PR TITLE
Upgrade to Scala 2.12, refactor tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,10 @@
 language: scala
-
 jdk:
   - oraclejdk8
-
 scala:
-  - 2.11.8
-
-services:
-  - docker
-
-before_install:
-- docker pull turbolent/spacy-thrift
-- docker run -d -p 9090:9090 turbolent/spacy-thrift
-- docker ps -a
-
-
+  - 2.12.1
 env:
   global:
     secure: "pSr5spAPfut9mPHHrWAkWXhx76CfR3ew+VwIJGNv4RZ8rZaI45djCZpWCGfXSRc21IFpi1Auke9FPEhfVVkhlQ9ADdepxdDfmk+c1bHX71sg/nzUmbeHIFcg/td1xcU9qshFgoisZSgYZ2qO3EsjoIjH+hoFo88l42Sd1uXNeNCmA6Xvc/o+Ni1C8q0/jXOmPmfZSqt2xWFxOPz0Jhl4UZnDMn5vKWlNd4uVUYS03tAl+ulJHqDFVxwU+UCME01jIMa0dFkWjNdbx/a5BntT4IJGOyqNwsQJ0NJZtlfmjEwLKXiZdTi0CyOXIgMfnf1S+M1AjZwGwG0Ib5lhgRnE643kjidwxSwK+yJJEjKGiVCzMa0rMH+XPDXBksXDizWRUaWyRPgU9SnnaUsef3C6PQU81U+qjF0+4oFubNaDu8L18pBTybr080+U1O9SCr81SlPIkzt75f8JYK0kME2kLgCj2yNEwrf6m0AaJCe34Kj7jRmM2JRS4/fEoal4OeaHgCOUx7dnjYQVTE7bQXL59eh5aFpXoGGlIbIBjo1uN/QiBA1CZtYoVlZvUVeDIxjkz2j7mjTZChm+3I4fRBXuUCAkfdNbNyGhVrgniwwVIJvzIIi4dL9Og3D2AQVgZdm812WuP61wW5ZNrx6+ehUTAl7g8PN8CcHlnIvlodnyYoU="
-
 after_success:
   - .travis/deploy.sh
-

--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,9 @@ libraryDependencies ++= Seq(
   "com.turbolent" %% "question-compiler" % "1.1-SNAPSHOT",
   "com.turbolent" %% "wikidata-ontology" % "1.1-SNAPSHOT",
   "com.turbolent" %% "spacy-thrift-scala" % "0.1-SNAPSHOT",
-  "org.json4s" %% "json4s-native" % "3.3.0",
   "com.twitter" %% "finagle-http" % "6.42.0",
   "com.twitter" %% "twitter-server" % "1.27.0",
+  "org.json4s" %% "json4s-jackson" % "3.5.0",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.turbolent"
 name := "question-server"
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
 
 scalacOptions ++= Seq("-feature", "-Xfatal-warnings")
 
@@ -13,10 +13,10 @@ libraryDependencies ++= Seq(
   "com.turbolent" %% "question-compiler" % "1.1-SNAPSHOT",
   "com.turbolent" %% "wikidata-ontology" % "1.1-SNAPSHOT",
   "com.turbolent" %% "spacy-thrift-scala" % "0.1-SNAPSHOT",
-  "com.twitter" %% "finagle-http" % "6.35.0",
-  "com.twitter" %% "twitter-server" % "1.20.0",
   "org.json4s" %% "json4s-native" % "3.3.0",
-  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+  "com.twitter" %% "finagle-http" % "6.42.0",
+  "com.twitter" %% "twitter-server" % "1.27.0",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 publishMavenStyle := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.11
+sbt.version=0.13.13
 

--- a/src/main/scala/com/turbolent/questionServer/QuestionServer.scala
+++ b/src/main/scala/com/turbolent/questionServer/QuestionServer.scala
@@ -37,13 +37,11 @@ object QuestionServer extends App with Logging {
     })
   }
 
-  def getService(spacyThriftHostname: String = defaultSpacyThriftHostname,
-                 spacyThriftPort: Int = defaultSpacyThriftPort,
+  def getService(tagger: Tagger,
                  parseLog: String = defaultLog,
                  accessLog: String = defaultLog) =
   {
-    val spacyThriftClient = new SpacyThriftClient(spacyThriftHostname, spacyThriftPort)
-    val parseService = new QuestionService(spacyThriftClient)
+    val parseService = new QuestionService(tagger)
 
     val routingService =
       RoutingService.byMethodAndPathObject[Request] {
@@ -59,8 +57,13 @@ object QuestionServer extends App with Logging {
   }
 
   def main() {
-    val service = getService(spacyThriftHostname = spacyThriftHostnameFlag(),
-      spacyThriftPort = spacyThriftPortFlag(),
+    val spacyThriftHostname = spacyThriftHostnameFlag()
+    val spacyThriftPort = spacyThriftPortFlag()
+
+    val spacyThriftClient = new SpacyThriftClient(spacyThriftHostname, spacyThriftPort)
+    val tagger = new SpacyTagger(spacyThriftClient)
+
+    val service = getService(tagger,
       parseLog = parseLogFlag(),
       accessLog = accessLogFlag())
     val server = Http.serve(":" + portFlag(), service)

--- a/src/main/scala/com/turbolent/questionServer/QuestionService.scala
+++ b/src/main/scala/com/turbolent/questionServer/QuestionService.scala
@@ -1,20 +1,16 @@
 package com.turbolent.questionServer
 
-import java.nio.file.Path
-
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.logging.Level.INFO
 import com.twitter.logging.Logger
 import com.twitter.util.Future
 import org.json4s.FullTypeHints
-import org.json4s.native.Serialization
-import spacyThrift.client.SpacyThriftClient
+import org.json4s.jackson.Serialization
 
 
-class QuestionService(spacyThriftClient: SpacyThriftClient)
-    extends Service[Request, Response]
-{
+class QuestionService(tagger: Tagger) extends Service[Request, Response] {
+
   val log = Logger(classOf[QuestionService])
   log.setUseParentHandlers(false)
   log.setLevel(INFO)
@@ -38,7 +34,7 @@ class QuestionService(spacyThriftClient: SpacyThriftClient)
     Future.value(response)
   }
 
-  val tokenizeSentence = new TokenizeSentenceStep(spacyThriftClient)
+  val tokenizeSentence = new TokenizeSentenceStep(tagger)
 
   def apply(req: Request): Future[Response] = {
     val steps = GetSentenceStep

--- a/src/main/scala/com/turbolent/questionServer/SpacyTagger.scala
+++ b/src/main/scala/com/turbolent/questionServer/SpacyTagger.scala
@@ -1,0 +1,14 @@
+package com.turbolent.questionServer
+import com.turbolent.questionParser.Token
+import com.twitter.util.Future
+import spacyThrift.client.SpacyThriftClient
+
+class SpacyTagger(client: SpacyThriftClient) extends Tagger {
+
+  override def tag(sentence: String): Future[Seq[Token]] =
+    client.tag(sentence) map { _ map {
+        case spacyThrift.Token(word, tag, lemma) =>
+          Token(word, tag, lemma)
+      }
+    }
+}

--- a/src/main/scala/com/turbolent/questionServer/Tagger.scala
+++ b/src/main/scala/com/turbolent/questionServer/Tagger.scala
@@ -1,0 +1,8 @@
+package com.turbolent.questionServer
+
+import com.turbolent.questionParser.Token
+import com.twitter.util.Future
+
+trait Tagger {
+  def tag(sentence: String): Future[Seq[Token]]
+}

--- a/src/main/scala/com/turbolent/questionServer/TokenizeSentenceStep.scala
+++ b/src/main/scala/com/turbolent/questionServer/TokenizeSentenceStep.scala
@@ -3,19 +3,12 @@ package com.turbolent.questionServer
 
 import com.turbolent.questionParser.Token
 import com.twitter.finagle.http.Request
-import com.twitter.util.Future
-import spacyThrift.client.SpacyThriftClient
 
 
-class TokenizeSentenceStep(spacyThriftClient: SpacyThriftClient)
-    extends QuestionStep[String, Seq[Token]]
-{
+class TokenizeSentenceStep(tagger: Tagger) extends QuestionStep[String, Seq[Token]] {
 
   def apply(req: Request, sentence: String, response: QuestionResponse) =
-    spacyThriftClient.tag(sentence).map { spacyTokens =>
-      val tokens = spacyTokens.map {
-        case spacyThrift.Token(word, tag, lemma) => Token(word, tag, lemma)
-      }
+    tagger.tag(sentence).map { tokens =>
       (tokens, response + ("tokens" -> tokens))
     }
 }

--- a/src/test/scala/QuestionServerSuite.scala
+++ b/src/test/scala/QuestionServerSuite.scala
@@ -1,8 +1,8 @@
 import com.turbolent.questionServer.QuestionServer
 import com.twitter.finagle.http._
 import org.json4s.DefaultFormats
-import org.json4s.native.JsonMethods
 import org.scalatest.junit.JUnitRunner
+import org.json4s.jackson.JsonMethods
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSuite, Matchers, OptionValues, TryValues}
 

--- a/src/test/scala/QuestionServerSuite.scala
+++ b/src/test/scala/QuestionServerSuite.scala
@@ -1,7 +1,8 @@
+import com.turbolent.questionParser.Token
 import com.turbolent.questionServer.QuestionServer
 import com.twitter.finagle.http._
+import com.twitter.util.Future
 import org.json4s.DefaultFormats
-import org.scalatest.junit.JUnitRunner
 import org.json4s.jackson.JsonMethods
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSuite, Matchers, OptionValues, TryValues}
@@ -15,7 +16,15 @@ class QuestionServerSuite extends FunSuite
     with OptionValues
 {
 
-  val service = QuestionServer.getService()
+  val tokens = Map(
+    "" -> Seq(),
+    "who" -> Seq(Token("who", "WP", "who")),
+    "who is" -> Seq(Token("who", "WP", "who"), Token("is", "VBD", "be")),
+    "who died" -> Seq(Token("who", "WP", "who"), Token("died", "VBD", "die"))
+  )
+
+  val service = QuestionServer.getService((sentence: String) =>
+    Future.value(tokens(sentence)))
 
   implicit val formats = DefaultFormats
 


### PR DESCRIPTION
- Upgrade to Scala 2.12 and also update dependencies
- Introduce `Tagger` trait, so tests don't have to rely on spaCy